### PR TITLE
Small  patch to solve decreasing=TRUE case in plotRanking

### DIFF
--- a/R/plotting.R
+++ b/R/plotting.R
@@ -302,6 +302,13 @@ plotRanking <- function (pvalues, summary, alpha=0.05, cex=0.75, decreasing=FALS
   
   k <- length(summary)
   
+  # dirty patch to for decreasing=TRUE case
+  if(decreasing)
+  {
+   summary <- k - summary + 1
+   decreasing = FALSE
+  }
+  
   if (is.matrix(summary)) {
     if (ncol(summary) == 1) {
       summary <- summary[, 1]    


### PR DESCRIPTION
I think that the function plotRanking may have a bug in the case decreasing=TRUE, where the horizontal lines span the whole length. The example in the documentation is used, with decreasing = TRUE . See photo below:

`data(data_gh_2008)`
`test <- postHocTest(data.gh.2008, test="friedman", correct="bergmann", use.rank=TRUE)`
`plotRanking(pvalues=test$corrected.pval, summary=test$summary, alpha=0.05, decreasing =TRUE)`

![decreasing_not_working](https://user-images.githubusercontent.com/44847157/76172571-cf0e5380-6197-11ea-8a13-fd6455d981d0.png)

This fix only inverts the ranking at the beginning, and sets  decreasing=FALSE. The result after the patch: 
![actual_corrected_plotRanking](https://user-images.githubusercontent.com/44847157/76172792-97081000-6199-11ea-9d9e-ecd657d89601.png)

